### PR TITLE
Bad identification for MS SQL Server driver templates

### DIFF
--- a/examples/org.eclipse.datatools.enablement.rcp/dtprcp.product
+++ b/examples/org.eclipse.datatools.enablement.rcp/dtprcp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="DTP Enablement RCP" uid="org.eclipse.datatools.enablement.rcp" id="org.eclipse.datatools.enablement.rcp.product" application="org.eclipse.datatools.enablement.rcp.application" version="1.0.0.qualifier" useFeatures="false" includeLaunchers="true">
+<product name="DTP Enablement RCP" uid="org.eclipse.datatools.enablement.rcp" id="org.eclipse.datatools.enablement.rcp.product" application="org.eclipse.datatools.enablement.rcp.application" version="1.1.0.qualifier" useFeatures="false" includeLaunchers="true">
 
    <aboutInfo>
       <image path="/org.eclipse.datatools.enablement.rcp/icons/alt_about.gif"/>

--- a/features/org.eclipse.datatools.enablement.msft.feature/feature.xml
+++ b/features/org.eclipse.datatools.enablement.msft.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.datatools.enablement.msft.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.datatools.enablement.finfo">
 

--- a/features/org.eclipse.datatools.enablement.msft.feature/pom.xml
+++ b/features/org.eclipse.datatools.enablement.msft.feature/pom.xml
@@ -9,5 +9,6 @@
   </parent>
   <groupId>org.eclipse.datatools.features</groupId>
   <artifactId>org.eclipse.datatools.enablement.msft.feature</artifactId>
+    <version>1.16.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/plugins/enablement/org.eclipse.datatools.enablement.msft.sqlserver/META-INF/MANIFEST.MF
+++ b/plugins/enablement/org.eclipse.datatools.enablement.msft.sqlserver/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name:  %pluginName
 Bundle-SymbolicName: org.eclipse.datatools.enablement.msft.sqlserver;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.4.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/plugins/enablement/org.eclipse.datatools.enablement.msft.sqlserver/plugin.properties
+++ b/plugins/enablement/org.eclipse.datatools.enablement.msft.sqlserver/plugin.properties
@@ -33,6 +33,7 @@ org.eclipse.datatools.enablement.msft.sqlserver.2012.driverTemplate = Microsoft 
 org.eclipse.datatools.enablement.msft.sqlserver.2008.driverTemplate = Microsoft SQL Server 2008 JDBC Driver
 org.eclipse.datatools.enablement.msft.sqlserver.2005.driverTemplate = Microsoft SQL Server 2005 JDBC Driver
 org.eclipse.datatools.enablement.msft.sqlserver.2000.driverTemplate = Microsoft SQL Server 2000 Driver for JDBC
+org.eclipse.datatools.enablement.msft.sqlserver.2016.other.driverTemplate = Other Driver
 org.eclipse.datatools.enablement.msft.sqlserver.2014.other.driverTemplate = Other Driver
 org.eclipse.datatools.enablement.msft.sqlserver.2012.other.driverTemplate = Other Driver
 org.eclipse.datatools.enablement.msft.sqlserver.2008.other.driverTemplate = Other Driver

--- a/plugins/enablement/org.eclipse.datatools.enablement.msft.sqlserver/pom.xml
+++ b/plugins/enablement/org.eclipse.datatools.enablement.msft.sqlserver/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.eclipse.datatools.plugins</groupId>
   <artifactId>org.eclipse.datatools.enablement.msft.sqlserver</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Add missing property
org.eclipse.datatools.enablement.msft.sqlserver.2016.other.driverTemplate

https://github.com/eclipse-datatools/datatools/issues/5