### PR TITLE
Disable entity-related security features SaxParser

### DIFF
--- a/features/org.eclipse.datatools.enablement.oda.feature/feature.xml
+++ b/features/org.eclipse.datatools.enablement.oda.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.datatools.enablement.oda.feature"
       label="%featureName"
-      version="1.15.0.qualifier"
+      version="1.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.datatools.enablement.oda.xml">
 

--- a/features/org.eclipse.datatools.enablement.oda.feature/pom.xml
+++ b/features/org.eclipse.datatools.enablement.oda.feature/pom.xml
@@ -9,5 +9,6 @@
   </parent>
   <groupId>org.eclipse.datatools.features</groupId>
   <artifactId>org.eclipse.datatools.enablement.oda.feature</artifactId>
+  <version>1.16.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.datatools.sdk.feature/feature.xml
+++ b/features/org.eclipse.datatools.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.datatools.sdk.feature"
       label="%featureName"
-      version="1.16.1.qualifier"
+      version="1.16.2.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.datatools.sdk">
 

--- a/features/org.eclipse.datatools.sdk.feature/pom.xml
+++ b/features/org.eclipse.datatools.sdk.feature/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.eclipse.datatools.features</groupId>
   <artifactId>org.eclipse.datatools.sdk.feature</artifactId>
-  <version>1.16.1-SNAPSHOT</version>
+  <version>1.16.2-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/META-INF/MANIFEST.MF
+++ b/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.eclipse.datatools.enablement.oda.xml;singleton:=true
-Bundle-Version: 1.5.0.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse Data Tools Platform

--- a/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/pom.xml
+++ b/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.eclipse.datatools.plugins</groupId>
   <artifactId>org.eclipse.datatools.enablement.oda.xml</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/src/org/eclipse/datatools/enablement/oda/xml/util/SaxParser.java
+++ b/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/src/org/eclipse/datatools/enablement/oda/xml/util/SaxParser.java
@@ -112,6 +112,8 @@ public class SaxParser extends DefaultHandler implements Runnable
 			//we are meeting now.
 			Object xmlReader = createXMLReader( );
 	
+			setFeatures( xmlReader );
+
 			setContentHandler( xmlReader );
 			
 			setErrorHandler( xmlReader );
@@ -186,6 +188,29 @@ public class SaxParser extends DefaultHandler implements Runnable
 				} );
 		this.invokeMethod( setErrorHandler, xmlReader, new Object[]{this} );
 	}
+
+	/**
+	 * 
+	 * @param xmlReader
+	 * @throws NoSuchMethodException
+	 * @throws IllegalAccessException
+	 * @throws InvocationTargetException
+	 */
+	private void setFeatures( Object xmlReader ) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException
+	{
+		Method setFeature = this.getMethod( "setFeature",//$NON-NLS-1$
+				xmlReader.getClass( ),
+				new Class[]{
+					String.class,
+					boolean.class
+				} );
+
+		this.invokeMethod(setFeature, xmlReader, new Object[] { "http://apache.org/xml/features/disallow-doctype-decl", true });
+		this.invokeMethod(setFeature, xmlReader, new Object[] { "http://apache.org/xml/features/nonvalidating/load-external-dtd", false});
+		this.invokeMethod(setFeature, xmlReader, new Object[] { "http://xml.org/sax/features/external-general-entities", false });
+		this.invokeMethod(setFeature, xmlReader, new Object[] { "http://xml.org/sax/features/external-parameter-entities", false });
+	}
+
 
 	/**
 	 * 

--- a/tp/org.eclipse.datatools.tp.target
+++ b/tp/org.eclipse.datatools.tp.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from DTP" sequenceNumber="27">
+<target name="Generated from DTP" sequenceNumber="28">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="a.jre.javase" version="0.0.0"/>
@@ -22,6 +22,18 @@
       <unit id="jakarta.inject.jakarta.inject-api" version="0.0.0"/>
       <unit id="jakarta.xml.bind-api" version="0.0.0"/>
       <unit id="javax.wsdl" version="0.0.0"/>
+      <unit id="junit-jupiter-api" version="0.0.0"/>
+      <unit id="junit-jupiter-engine" version="0.0.0"/>
+      <unit id="junit-jupiter-migrationsupport" version="0.0.0"/>
+      <unit id="junit-jupiter-params" version="0.0.0"/>
+      <unit id="junit-platform-commons" version="0.0.0"/>
+      <unit id="junit-platform-engine" version="0.0.0"/>
+      <unit id="junit-platform-launcher" version="0.0.0"/>
+      <unit id="junit-platform-runner" version="0.0.0"/>
+      <unit id="junit-platform-suite-api" version="0.0.0"/>
+      <unit id="junit-platform-suite-commons" version="0.0.0"/>
+      <unit id="junit-platform-suite-engine" version="0.0.0"/>
+      <unit id="junit-vintage-engine" version="0.0.0"/>
       <unit id="org.apache.aries.spifly.dynamic.bundle" version="0.0.0"/>
       <unit id="org.apache.batik.constants" version="0.0.0"/>
       <unit id="org.apache.batik.css" version="0.0.0"/>
@@ -30,23 +42,28 @@
       <unit id="org.apache.commons.collections" version="0.0.0"/>
       <unit id="org.apache.commons.commons-beanutils" version="0.0.0"/>
       <unit id="org.apache.commons.commons-io" version="0.0.0"/>
-      <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
       <unit id="org.apache.commons.jxpath" version="0.0.0"/>
+      <unit id="org.apache.commons.logging" version="0.0.0"/>
       <unit id="org.apache.felix.scr" version="0.0.0"/>
       <unit id="org.apache.lucene.analysis-common" version="0.0.0"/>
       <unit id="org.apache.lucene.analysis-smartcn" version="0.0.0"/>
       <unit id="org.apache.lucene.core" version="0.0.0"/>
+      <unit id="org.apache.lucene.facet" version="0.0.0"/>
       <unit id="org.apache.lucene.queries" version="0.0.0"/>
       <unit id="org.apache.lucene.queryparser" version="0.0.0"/>
       <unit id="org.apache.lucene.sandbox" version="0.0.0"/>
       <unit id="org.apache.xerces" version="0.0.0"/>
       <unit id="org.apache.xml.resolver" version="0.0.0"/>
+      <unit id="org.apache.xmlgraphics" version="0.0.0"/>
+      <unit id="org.apiguardian.api" version="0.0.0"/>
       <unit id="org.bndtools.headless.build.manager" version="0.0.0"/>
       <unit id="org.bndtools.headless.build.plugin.gradle" version="0.0.0"/>
       <unit id="org.bndtools.templates.template" version="0.0.0"/>
       <unit id="org.bndtools.templating" version="0.0.0"/>
       <unit id="org.bndtools.versioncontrol.ignores.manager" version="0.0.0"/>
       <unit id="org.bndtools.versioncontrol.ignores.plugin.git" version="0.0.0"/>
+      <unit id="org.commonmark" version="0.0.0"/>
+      <unit id="org.commonmark-gfm-tables" version="0.0.0"/>
       <unit id="org.eclipse.e4.tools.emf.ui" version="0.0.0"/>
       <unit id="org.eclipse.e4.tools.services" version="0.0.0"/>
       <unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>
@@ -77,6 +94,7 @@
       <unit id="org.eclipse.search.core" version="0.0.0"/>
       <unit id="org.hamcrest" version="0.0.0"/>
       <unit id="org.jdom" version="0.0.0"/>
+      <unit id="org.junit" version="0.0.0"/>
       <unit id="org.mortbay.jasper.apache-el" version="0.0.0"/>
       <unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
       <unit id="org.objectweb.asm" version="0.0.0"/>
@@ -84,6 +102,7 @@
       <unit id="org.objectweb.asm.tree" version="0.0.0"/>
       <unit id="org.objectweb.asm.tree.analysis" version="0.0.0"/>
       <unit id="org.objectweb.asm.util" version="0.0.0"/>
+      <unit id="org.opentest4j" version="0.0.0"/>
       <unit id="org.osgi.annotation.bundle" version="0.0.0"/>
       <unit id="org.osgi.annotation.versioning" version="0.0.0"/>
       <unit id="org.osgi.namespace.contract" version="0.0.0"/>
@@ -105,7 +124,7 @@
       <repository location="https://download.eclipse.org/modeling/mdt/ocl/updates/releases/latest"/>
       <repository location="https://download.eclipse.org/tools/gef/classic/releases/latest"/>
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
-      <repository location="https://download.eclipse.org/eclipse/updates/4.33-I-builds"/>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.34-I-builds"/>
     </location>
   </locations>
 </target>


### PR DESCRIPTION
- Add org.eclipse.datatools.enablement.oda.xml.util.SaxParser.setFeatures for setting the xerces parser features.

Fixes https://github.com/eclipse-datatools/datatools/issues/22