### PR TITLE
Enhance ISaxParserConsumer to support ErrorHandler methods

### DIFF
--- a/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/src/org/eclipse/datatools/enablement/oda/xml/util/ISaxParserConsumer.java
+++ b/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/src/org/eclipse/datatools/enablement/oda/xml/util/ISaxParserConsumer.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package org.eclipse.datatools.enablement.oda.xml.util;
 
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
 /**
  * This interface defined the methods that would be used by classes that use sax parser.
  */
@@ -28,4 +31,23 @@ public interface ISaxParserConsumer
 	public void endElement( XMLPath path );
 	
 	public void finish( );
+
+	/**
+	 * @since 1.6
+	 */
+	default void warning(SAXParseException exception) throws SAXException {
+	}
+
+	/**
+	 * @since 1.6
+	 */
+	default void error(SAXParseException exception) throws SAXException {
+	}
+
+	/**
+	 * @since 1.6
+	 */
+	default void fatalError(SAXParseException exception) throws SAXException {
+		throw exception;
+	}
 }

--- a/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/src/org/eclipse/datatools/enablement/oda/xml/util/SaxParser.java
+++ b/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/src/org/eclipse/datatools/enablement/oda/xml/util/SaxParser.java
@@ -28,6 +28,7 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
@@ -444,7 +445,21 @@ public class SaxParser extends DefaultHandler implements Runnable
 		this.stopFlag = true;
 	}
 
-	
+	@Override
+	public void warning(SAXParseException e) throws SAXException {
+		spConsumer.warning(e);
+	}
+
+	@Override
+	public void error(SAXParseException e) throws SAXException {
+		spConsumer.error(e);
+	}
+
+	@Override
+	public void fatalError(SAXParseException e) throws SAXException {
+		spConsumer.fatalError(e);
+	}
+
 	/**
 	 * This class wrapps a RuntimeException. It is used to stop the execution of
 	 * current thread.

--- a/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/src/org/eclipse/datatools/enablement/oda/xml/util/SaxParserConsumer.java
+++ b/plugins/enablement/org.eclipse.datatools.enablement.oda.xml/src/org/eclipse/datatools/enablement/oda/xml/util/SaxParserConsumer.java
@@ -21,6 +21,8 @@ import java.util.Map;
 
 import org.eclipse.datatools.connectivity.oda.OdaException;
 import org.eclipse.datatools.enablement.oda.xml.Constants;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 /**
  * This class is an implementation of ISaxParserConsumer. The instance of this
@@ -54,6 +56,7 @@ public class SaxParserConsumer implements ISaxParserConsumer
 
 	private SaxParserNestedQueryHelper spNestedQueryHelper;
 
+	private SAXException fatalError;
 
 	//List<Row>: The detected but not filled yet rows, managed and accessed only by XML parsing thread
 	private List processingRows = new ArrayList( );
@@ -374,6 +377,9 @@ public class SaxParserConsumer implements ISaxParserConsumer
 			{
 			}
 		}
+		if (fatalError != null) {
+			throw new OdaException(fatalError);
+		}
 		boolean hasNext = prv.next( );
 		if ( !hasNext && prv.size( ) >= Constants.CACHED_RESULT_SET_LENGTH && spThread.isAlive( ))
 		{
@@ -414,6 +420,12 @@ public class SaxParserConsumer implements ISaxParserConsumer
 			}
 			sp.stopParsing( );
 		}
+	}
+
+	@Override
+	public void fatalError(SAXParseException exception) throws SAXException {
+		fatalError = exception;
+		ISaxParserConsumer.super.fatalError(exception);
 	}
 
 	/**


### PR DESCRIPTION
- Support the same methods as org.xml.sax.ErrorHandler as default methods.
- Delegate from org.eclipse.datatools.enablement.oda.xml.util.SaxParser to those new methods on the consumer.
- Recored a fatal error in org.eclipse.datatools.enablement.oda.xml.util.SaxParserConsumer.fatalError and throw it from next() wrapped as an OdaException.

https://github.com/eclipse-datatools/datatools/issues/24